### PR TITLE
minor `Ibex.matrix()` bugfix & cleanup

### DIFF
--- a/man/Ibex.matrix.Rd
+++ b/man/Ibex.matrix.Rd
@@ -87,3 +87,6 @@ ibex_values <- Ibex.matrix(ibex_example,
 \code{\link[immApex]{propertyEncoder}}, 
 \code{\link[immApex]{geometricEncoder}}
 }
+\author{
+Nick Borcherding, Qile Yang
+}

--- a/man/filter.cells.Rd
+++ b/man/filter.cells.Rd
@@ -4,7 +4,7 @@
 \alias{filter.cells}
 \title{Filter Single-Cell Data Based on CDR3 Sequences}
 \usage{
-\method{filter}{cells}(sc.obj, chain)
+filter.cells(sc.obj, chain)
 }
 \arguments{
 \item{sc.obj}{A Seurat or SingleCellExperiment object.}


### PR DESCRIPTION
@ncborcherding There was a redundant use of `ifelse()` in `Ibex.matrix()` that would've errored if `chain="light"` because `ifelse()` assumes all arguments are either length 1 or have equal max lengths. Additionally did a teeny bit of cleanup.

Is `dev` still the right branch to PR into? It seems quite far behind main. Perhaps a merge is needed?